### PR TITLE
Fix RegExp handling across contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ getDirs(__dirname, exclusions, readableStream => {
 
 Tested on Mac OSX only so far.
 
-**note**: running the above example in the node REPL will cause an error — the `get-dirs`
-module will claim that the RegExp is not actually an `instanceof RegExp`. I don't know why,
-but it will work fine run inside a `js` file. If anyone knows why please feel free to enlighten me.
+**note**: prior versions of this package used `instanceof RegExp` to validate the
+`exclude` argument. In some versions of the Node REPL each expression is
+evaluated in its own context, so a `RegExp` created there would fail the check.
+The library now performs a context-agnostic test, so the example works in the
+REPL as well as in a script.
 
 ## Run unit tests
 ```sh

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function getDirs(rootDir, exclude = [], cb) {
       exclude = exclude.map(v => {
         if(typeof v === 'string') {
           return new RegExp(v, 'i')
-        } else if(v instanceof RegExp) {
+        } else if(isRegExp(v)) {
           return v
         } else {
           throw new Error('Only strings or RegExp objects are allowed in exclude array. There is a problem with value: ' + v + ', which is an instance of: ' + Object.getPrototypeOf(v))
@@ -94,4 +94,8 @@ module.exports = function getDirs(rootDir, exclude = [], cb) {
 
 function isUndefined(v) {
   return typeof v === 'undefined'
+}
+
+function isRegExp(v) {
+  return Object.prototype.toString.call(v) === '[object RegExp]'
 }

--- a/test/index.js
+++ b/test/index.js
@@ -126,3 +126,19 @@ tape.test('callback function is allowed to be passed as second argument', t => {
     )
   })
 })
+
+tape.test('it accepts RegExp objects created in another context', t => {
+  const vm = require('vm')
+  const regex = vm.runInNewContext('/folderB/')
+  getDirs(testDir, [regex], readableStream => {
+    readableStream.pipe(
+      callbackStream((err, dirs) => {
+        t.deepEqual(dirs, [
+          Buffer.from(`${testDir}/folderA`),
+          Buffer.from(`${testDir}/folderA/folderAA`),
+        ])
+        t.end()
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- use a context-agnostic check for RegExp
- clarify REPL behaviour in README
- add regression test for cross-context RegExp objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abd5269d4832798dfc6d1be2a6b3e